### PR TITLE
feat: 스터디 대시보드 게시글 기능 및 UI 개선

### DIFF
--- a/src/study/dashboard/StudyMain.css
+++ b/src/study/dashboard/StudyMain.css
@@ -206,11 +206,9 @@
 }
 
 .nickname {
-  font-size: 14px;
+  font-size: 14px !important;
   text-align: center;
-  display: flex;
-  align-items: center;
-  flex-direction: column;
+  margin-top: 5px;
 }
 
 .post-right {
@@ -240,21 +238,21 @@
 
 .post-bottom {
   display: flex;
-  justify-content: space-between;
-  align-items: center;
   padding-top: 10px;
-}
-
-.post-date {
-  font-size: 14px;
-  color: #666;
-  right: 0;
 }
 
 .post-actions {
   display: flex;
   gap: 5px;
+  margin-right: 20px;
 }
+
+.post-date {
+  font-size: 14px;
+  color: #666;
+  
+}
+
 
 .post-actions button {
   background: none;
@@ -272,4 +270,32 @@
   border-radius: 4px;
   font-size: 12px;
   margin-bottom: 4px;
+}
+
+/* 수정 모드 input, textarea 스타일 */
+.post-content-area input {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 8px;
+  box-sizing: border-box;
+}
+
+.post-content-area textarea {
+  width: 100%;
+  padding: 8px 12px;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  font-size: 14px;
+  line-height: 1.5;
+  min-height: 80px;
+}
+
+.post-content-area input:focus,
+.post-content-area textarea:focus {
+  outline: none;
+  border-color: #FDB515;
 }

--- a/src/study/dashboard/StudyMain.jsx
+++ b/src/study/dashboard/StudyMain.jsx
@@ -155,31 +155,71 @@ export default function StudyMain() {
     setEditedContent('');
   };
 
+  // const handleConfirmEdit = async () => {
+  //   try {
+  //     const res = await fetch(`${host}/api/study/board`, {
+  //       method: 'PUT',
+  //       headers: {
+  //         'Content-Type': 'application/json',
+  //         'X-USER-ID': user.id
+  //       },
+  //       body: JSON.stringify({
+  //         id: editingPostId,
+  //         userId: user.id,
+  //         groupId: groupId,
+  //         dashboardPostTitle: editedTitle,
+  //         dashboardPostText: editedContent
+  //       })
+  //     });
+
+  //     if (!res.ok) throw new Error('수정 실패');
+
+  //     await fetchPosts();
+  //     handleCancelEdit(); // 편집상태 종료
+  //   } catch (error) {
+  //     console.error('수정 오류', error);
+  //   }
+  // };
+
   const handleConfirmEdit = async () => {
-    try {
-      const res = await fetch(`${host}/api/study/board`, {
-        method: 'PUT',
-        headers: {
-          'Content-Type': 'application/json',
-          'X-USER-ID': user.id
-        },
-        body: JSON.stringify({
-          id: editingPostId,
-          userId: user.id,
-          groupId: groupId,
-          dashboardPostTitle: editedTitle,
-          dashboardPostText: editedContent
-        })
-      });
+  try {
+    const res = await fetch(`${host}/api/study/board`, {
+      method: 'PUT',
+      headers: {
+        'Content-Type': 'application/json',
+        'X-USER-ID': user.id
+      },
+      body: JSON.stringify({
+        id: editingPostId,
+        userId: user.id,
+        groupId: groupId,
+        dashboardPostTitle: editedTitle,
+        dashboardPostText: editedContent
+      })
+    });
 
-      if (!res.ok) throw new Error('수정 실패');
+    if (!res.ok) throw new Error('수정 실패');
 
-      await fetchPosts();
-      handleCancelEdit(); // 편집상태 종료
-    } catch (error) {
-      console.error('수정 오류', error);
-    }
-  };
+    // 상태 직접 업데이트 (fetchPosts 없이)
+    setAllNotices(prev => prev.map(post => 
+      post.id === editingPostId 
+        ? { ...post, dashboardPostTitle: editedTitle, dashboardPostText: editedContent }
+        : post
+    ));
+    
+    setAllPosts(prev => prev.map(post => 
+      post.id === editingPostId 
+        ? { ...post, dashboardPostTitle: editedTitle, dashboardPostText: editedContent }
+        : post
+    ));
+
+    // 편집 상태 해제
+    handleCancelEdit();
+    
+  } catch (error) {
+    console.error('수정 오류', error);
+  }
+};
 
   const handleDelete = async (postId) => {
     if (!window.confirm('정말 삭제하시겠습니까?'))
@@ -300,126 +340,136 @@ export default function StudyMain() {
 
       {/* 전체 게시글 목록(공지 + 일반글) */}
       <ul className='all-post-list'>
-  {/* 공지글 먼저 출력 */}
-  {allNotices.map((post) => (
-    <li key={post.id} className='post-item notice'>
-      <div className='post-layout'>
-        {/* 왼쪽: 프로필 이미지 + 닉네임 */}
-        <div className='post-left'>
-          <img
-            src={post.writerProfileImage || '/default-profile.png'}
-            alt='프로필'
-            className='profile-img'
-          />
-          <div className='nickname'>{post.writerNickname}</div> {/* 뱃지 제거 */}
-        </div>
-
-        {/* 오른쪽: 글 제목 + 내용 + 하단(날짜, 수정삭제) */}
-        <div className='post-right'>
-          <div className='post-content-area'>
-            {editingPostId === post.id ? (
-              <>
-                <input
-                  value={editedTitle}
-                  onChange={(e) => setEditedTitle(e.target.value)}
+        {/* 공지글 먼저 출력 */}
+        {allNotices.map((post) => (
+          <li key={post.id} className='post-item notice'>
+            <div className='post-layout'>
+              {/* 왼쪽: 프로필 이미지 + 닉네임 */}
+              <div className='post-left'>
+                <img
+                  src={post.writerProfileImage ||
+                    (post.userId === user?.id ? user.profileImage : null) ||
+                    '/images/default-profile.png'}
+                  alt='프로필'
+                  className='profile-img'
                 />
-                <textarea
-                  value={editedContent}
-                  onChange={(e) => setEditedContent(e.target.value)}
-                />
-              </>
-            ) : (
-              <>
-                <div className='post-title'>
-                  <span className='badge'>공지</span> {/* 뱃지를 제목 앞으로 이동 */}
-                  {post.dashboardPostTitle}
+                <div className='nickname'>
+                  {post.writerNickname || (post.userId === user?.id ? user.nickname : '작성자')}
                 </div>
-                <p className='post-content'>{post.dashboardPostText}</p>
-              </>
-            )}
-          </div>
-
-          {/* 하단: 날짜 + 수정삭제 버튼 */}
-          <div className='post-bottom'>
-            <span className='post-date'>{post.createdAt?.slice(0, 10)}</span>
-            {user?.id === post.writerId && (
-              <div className='post-actions'>
-                {editingPostId === post.id ? (
-                  <>
-                    <button onClick={handleConfirmEdit}>확인</button>
-                    <button onClick={handleCancelEdit}>취소</button>
-                  </>
-                ) : (
-                  <>
-                    <button onClick={() => handleStartEdit(post)}>수정</button>
-                    <button onClick={() => handleDelete(post.id)}>삭제</button>
-                  </>
-                )}
               </div>
-            )}
-          </div>
-        </div>
-      </div>
-    </li>
-  ))}
 
-  {/* 일반글은 그대로 */}
-  {allPosts.map((post) => (
-    <li key={post.id} className='post-item'>
-      <div className='post-layout'>
-        <div className='post-left'>
-          <img
-            src={post.writerProfileImage || '/default-profile.png'}
-            alt='프로필'
-            className='profile-img'
-          />
-          <div className='nickname'>{post.writerNickname}</div>
-        </div>
+              {/* 오른쪽: 글 제목 + 내용 + 하단(날짜, 수정삭제) */}
+              <div className='post-right'>
+                <div className='post-content-area'>
+                  {editingPostId === post.id ? (
+                    <>
+                      <input
+                        value={editedTitle}
+                        onChange={(e) => setEditedTitle(e.target.value)}
+                      />
+                      <textarea
+                        value={editedContent}
+                        onChange={(e) => setEditedContent(e.target.value)}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <div className='post-title'>
+                        <span className='badge'>공지</span>
+                        {post.dashboardPostTitle}
+                      </div>
+                      <p className='post-content'>{post.dashboardPostText}</p>
+                    </>
+                  )}
+                </div>
 
-        <div className='post-right'>
-          <div className='post-content-area'>
-            {editingPostId === post.id ? (
-              <>
-                <input
-                  value={editedTitle}
-                  onChange={(e) => setEditedTitle(e.target.value)}
-                />
-                <textarea
-                  value={editedContent}
-                  onChange={(e) => setEditedContent(e.target.value)}
-                />
-              </>
-            ) : (
-              <>
-                <strong className='post-title'>{post.dashboardPostTitle}</strong>
-                <p className='post-content'>{post.dashboardPostText}</p>
-              </>
-            )}
-          </div>
-
-          <div className='post-bottom'>
-            <span className='post-date'>{post.createdAt?.slice(0, 10)}</span>
-            {user?.id === post.writerId && (
-              <div className='post-actions'>
-                {editingPostId === post.id ? (
-                  <>
-                    <button onClick={handleConfirmEdit}>확인</button>
-                    <button onClick={handleCancelEdit}>취소</button>
-                  </>
-                ) : (
-                  <>
-                    <button onClick={() => handleStartEdit(post)}>수정</button>
-                    <button onClick={() => handleDelete(post.id)}>삭제</button>
-                  </>
-                )}
+                {/* 하단: 날짜 + 수정삭제 버튼 */}
+                <div className='post-bottom'>
+                  
+                  {(user?.id === post.writerId || user?.id === post.userId) && (
+                    <div className='post-actions'>
+                      {editingPostId === post.id ? (
+                        <>
+                          <button onClick={handleConfirmEdit}>확인</button>
+                          <button onClick={handleCancelEdit}>취소</button>
+                        </>
+                      ) : (
+                        <>
+                          <button onClick={() => handleStartEdit(post)}>수정</button>
+                          <button onClick={() => handleDelete(post.id)}>삭제</button>
+                        </>
+                      )}
+                    </div>
+                  )}
+                  <span className='post-date'>{post.createdAt?.slice(0, 10)}</span>
+                </div>
               </div>
-            )}
-          </div>
-        </div>
-      </div>
-    </li>
-  ))}
-</ul>
+            </div>
+          </li>
+        ))}
+
+        {/* 일반글은 그대로 */}
+        {allPosts.map((post) => (
+          <li key={post.id} className='post-item'>
+            <div className='post-layout'>
+              <div className='post-left'>
+                <img
+                  src={post.writerProfileImage ||
+                    (post.userId === user?.id ? user.profileImage : null) ||
+                    '/images/default-profile.png'}
+                  alt='프로필'
+                  className='profile-img'
+                />
+                <div className='nickname'>
+                  {post.writerNickname || post.studyNickname || (post.userId === user?.id ? user.nickname : '작성자')}
+                </div>
+              </div>
+
+              <div className='post-right'>
+                <div className='post-content-area'>
+                  {editingPostId === post.id ? (
+                    <>
+                      <input
+                        value={editedTitle}
+                        onChange={(e) => setEditedTitle(e.target.value)}
+                      />
+                      <textarea
+                        value={editedContent}
+                        onChange={(e) => setEditedContent(e.target.value)}
+                      />
+                    </>
+                  ) : (
+                    <>
+                      <strong className='post-title'>{post.dashboardPostTitle}</strong>
+                      <p className='post-content'>{post.dashboardPostText}</p>
+                    </>
+                  )}
+                </div>
+
+                <div className='post-bottom'>
+                  
+                  {(user?.id === post.writerId || user?.id === post.userId) && (
+                    <div className='post-actions'>
+                      {editingPostId === post.id ? (
+                        <>
+                          <button onClick={handleConfirmEdit}>확인</button>
+                          <button onClick={handleCancelEdit}>취소</button>
+                        </>
+                      ) : (
+                        <>
+                          <button onClick={() => handleStartEdit(post)}>수정</button>
+                          <button onClick={() => handleDelete(post.id)}>삭제</button>
+                        </>
+                      )}
+                    </div>
+                  )}
+                  <span className='post-date'>{post.createdAt?.slice(0, 10)}</span>
+                </div>
+              </div>
+            </div>
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }

--- a/src/study/post/components/StudyCard.jsx
+++ b/src/study/post/components/StudyCard.jsx
@@ -2,6 +2,26 @@
 import React from "react";
 import "./StudyCard.css"; // 순수 CSS 파일을 import (기존 CSS 파일명 유지)
 
+const getThumbnailUrl = (group) => {
+  if (!group) {
+    return '/images/default-thumbnail.png';
+  }
+
+  // thumbnailFullPath가 있으면 S3 URL 사용
+  if (group.thumbnailFullPath && !group.thumbnailFullPath.includes('default')) {
+    return group.thumbnailFullPath;
+  }
+
+  // thumbnail 필드만 있는 경우 - GroupDetail과 동일한 URL 패턴 사용
+  if (group.thumbnail && !group.thumbnail.includes('default')) {
+    const fullUrl = `https://upload-bucket-study.s3.ap-northeast-2.amazonaws.com/uploads/studygroupimg/${group.thumbnail}`;
+    return fullUrl;
+  }
+
+  // 기본 이미지
+  return '/images/default-thumbnail.png';
+};
+
 // studyGroup 데이터와 함께 isSelected, onSelect props를 받습니다.
 const StudyCard = ({ studyGroup, isSelected, onSelect }) => {
   // console.log(isSelected, "isSelected");
@@ -50,12 +70,19 @@ const StudyCard = ({ studyGroup, isSelected, onSelect }) => {
 
         <div className="study-card-thumbnail">
           {/* thumbnailUrl이 있을 경우 이미지 표시, 없을 경우 플레이스홀더 표시 */}
-          <img
+          {/* <img
             src={
               studyGroup.thumbnailUrl ||
               "https://placehold.co/150x120/E0E0E0/FFFFFF?text=No+Img"
             }
             alt={`${studyGroup.groupName} 썸네일`}
+          /> */}
+          <img
+            src={getThumbnailUrl(studyGroup)}
+            alt={`${studyGroup.groupName} 썸네일`}
+            onError={(e) => {
+              e.target.src = '/images/default-thumbnail.png';
+            }}
           />
         </div>
       </div>


### PR DESCRIPTION
## 변경사항
- 스터디 대시보드 게시글 CRUD 기능 구현 (작성/조회/수정/삭제)
- 공지글/일반글 구분 표시 및 권한 처리 (스터디장만 공지 작성)
- 게시글 목록 레이아웃 및 UI 개선
- 스터디카드 S3 썸네일 이미지 불러오기 기능 적용
- 제목 말줄임표 처리 및 반응형 디자인

## 주요 기능
- 게시글 작성/수정/삭제 (본인 글만 수정/삭제 가능)
- 스터디장 권한으로 공지글 작성 가능
- 대시보드 상단 최신 글 미리보기 (공지 1개, 일반글 3개)
- 프로필 이미지 및 닉네임 표시
- 스터디카드 썸네일 S3 URL 처리

## 기술적 개선
- StudyMain 컴포넌트 게시글 관리 기능 완성
- StudyCard 썸네일 URL 처리 로직 개선
- CSS 레이아웃 및 스타일링 개선