### PR TITLE
대시보드 주간 캘린더 추가 및 월간 캘린더 연동

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,10 +8,11 @@
       "name": "react-study-o",
       "version": "0.0.0",
       "dependencies": {
-        "@fullcalendar/daygrid": "^6.1.18",
-        "@fullcalendar/interaction": "^6.1.18",
-        "@fullcalendar/react": "^6.1.18",
-        "@fullcalendar/timegrid": "^6.1.18",
+        "@fullcalendar/core": "^6.1.19",
+        "@fullcalendar/daygrid": "^6.1.19",
+        "@fullcalendar/interaction": "^6.1.19",
+        "@fullcalendar/react": "^6.1.19",
+        "@fullcalendar/timegrid": "^6.1.19",
         "react": "^18.2.0",
         "react-dom": "^18.2.0"
       },
@@ -952,54 +953,53 @@
       }
     },
     "node_modules/@fullcalendar/core": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.18.tgz",
-      "integrity": "sha512-cD7XtZIZZ87Cg2+itnpsONCsZ89VIfLLDZ22pQX4IQVWlpYUB3bcCf878DhWkqyEen6dhi5ePtBoqYgm5K+0fQ==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/core/-/core-6.1.19.tgz",
+      "integrity": "sha512-z0aVlO5e4Wah6p6mouM0UEqtRf1MZZPt4mwzEyU6kusaNL+dlWQgAasF2cK23hwT4cmxkEmr4inULXgpyeExdQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "preact": "~10.12.1"
       }
     },
     "node_modules/@fullcalendar/daygrid": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.18.tgz",
-      "integrity": "sha512-s452Zle1SdMEzZDw+pDczm8m3JLIZzS9ANMThXTnqeqJewW1gqNFYas18aHypJSgF9Fh9rDJjTSUw04BpXB/Mg==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/daygrid/-/daygrid-6.1.19.tgz",
+      "integrity": "sha512-IAAfnMICnVWPjpT4zi87i3FEw0xxSza0avqY/HedKEz+l5MTBYvCDPOWDATpzXoLut3aACsjktIyw9thvIcRYQ==",
       "license": "MIT",
       "peerDependencies": {
-        "@fullcalendar/core": "~6.1.18"
+        "@fullcalendar/core": "~6.1.19"
       }
     },
     "node_modules/@fullcalendar/interaction": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.18.tgz",
-      "integrity": "sha512-f/mD5RTjzw+Q6MGTMZrLCgIrQLIUUO9NV/58aM2J6ZBQZeRlNizDqmqldqyG+j49zj2vFhUfZibPrVKWm5yA4Q==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/interaction/-/interaction-6.1.19.tgz",
+      "integrity": "sha512-GOciy79xe8JMVp+1evAU3ytdwN/7tv35t5i1vFkifiuWcQMLC/JnLg/RA2s4sYmQwoYhTw/p4GLcP0gO5B3X5w==",
       "license": "MIT",
       "peerDependencies": {
-        "@fullcalendar/core": "~6.1.18"
+        "@fullcalendar/core": "~6.1.19"
       }
     },
     "node_modules/@fullcalendar/react": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.18.tgz",
-      "integrity": "sha512-Jwvb+T+/1yGZKe+UYXn0id022HJm0Fq2X/PGFvVh/QRYAI/6xPMRvJrwercBkToxf6LjqYXrDO+/NhRN6IDlmg==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/react/-/react-6.1.19.tgz",
+      "integrity": "sha512-FP78vnyylaL/btZeHig8LQgfHgfwxLaIG6sKbNkzkPkKEACv11UyyBoTSkaavPsHtXvAkcTED1l7TOunAyPEnA==",
       "license": "MIT",
       "peerDependencies": {
-        "@fullcalendar/core": "~6.1.18",
+        "@fullcalendar/core": "~6.1.19",
         "react": "^16.7.0 || ^17 || ^18 || ^19",
         "react-dom": "^16.7.0 || ^17 || ^18 || ^19"
       }
     },
     "node_modules/@fullcalendar/timegrid": {
-      "version": "6.1.18",
-      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.18.tgz",
-      "integrity": "sha512-T/ouhs+T1tM8JcW7Cjx+KiohL/qQWKqvRITwjol8ktJ1e1N/6noC40/obR1tyolqOxMRWHjJkYoj9fUqfoez9A==",
+      "version": "6.1.19",
+      "resolved": "https://registry.npmjs.org/@fullcalendar/timegrid/-/timegrid-6.1.19.tgz",
+      "integrity": "sha512-OuzpUueyO9wB5OZ8rs7TWIoqvu4v3yEqdDxZ2VcsMldCpYJRiOe7yHWKr4ap5Tb0fs7Rjbserc/b6Nt7ol6BRg==",
       "license": "MIT",
       "dependencies": {
-        "@fullcalendar/daygrid": "~6.1.18"
+        "@fullcalendar/daygrid": "~6.1.19"
       },
       "peerDependencies": {
-        "@fullcalendar/core": "~6.1.18"
+        "@fullcalendar/core": "~6.1.19"
       }
     },
     "node_modules/@humanfs/core": {
@@ -4429,6 +4429,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4445,6 +4446,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4456,11 +4458,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/emoji-regex": {
       "version": "9.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4477,6 +4481,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/cliui/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4491,6 +4496,7 @@
     },
     "node_modules/npm/node_modules/@isaacs/fs-minipass": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4502,11 +4508,13 @@
     },
     "node_modules/npm/node_modules/@isaacs/string-locale-compare": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/@npmcli/agent": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4522,6 +4530,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/arborist": {
       "version": "9.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4569,6 +4578,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/config": {
       "version": "10.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4587,6 +4597,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/fs": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4598,6 +4609,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/git": {
       "version": "6.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4616,6 +4628,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/installed-package-contents": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4631,6 +4644,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/map-workspaces": {
       "version": "4.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4645,6 +4659,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/metavuln-calculator": {
       "version": "9.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4660,6 +4675,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/name-from-folder": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4668,6 +4684,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/node-gyp": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4676,6 +4693,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/package-json": {
       "version": "6.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4693,6 +4711,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/promise-spawn": {
       "version": "8.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4704,6 +4723,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/query": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4715,6 +4735,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/redact": {
       "version": "3.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4723,6 +4744,7 @@
     },
     "node_modules/npm/node_modules/@npmcli/run-script": {
       "version": "9.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4739,6 +4761,7 @@
     },
     "node_modules/npm/node_modules/@pkgjs/parseargs": {
       "version": "0.11.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -4748,6 +4771,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/bundle": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4759,6 +4783,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/core": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4767,6 +4792,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/protobuf-specs": {
       "version": "0.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "engines": {
@@ -4775,6 +4801,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/sign": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4791,6 +4818,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/tuf": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4803,6 +4831,7 @@
     },
     "node_modules/npm/node_modules/@sigstore/verify": {
       "version": "2.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -4816,6 +4845,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/canonical-json": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4824,6 +4854,7 @@
     },
     "node_modules/npm/node_modules/@tufjs/models": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4836,6 +4867,7 @@
     },
     "node_modules/npm/node_modules/abbrev": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -4844,6 +4876,7 @@
     },
     "node_modules/npm/node_modules/agent-base": {
       "version": "7.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4852,6 +4885,7 @@
     },
     "node_modules/npm/node_modules/ansi-regex": {
       "version": "5.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4860,6 +4894,7 @@
     },
     "node_modules/npm/node_modules/ansi-styles": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4871,21 +4906,25 @@
     },
     "node_modules/npm/node_modules/aproba": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/archy": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/balanced-match": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/bin-links": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4901,6 +4940,7 @@
     },
     "node_modules/npm/node_modules/binary-extensions": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -4912,6 +4952,7 @@
     },
     "node_modules/npm/node_modules/brace-expansion": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4920,6 +4961,7 @@
     },
     "node_modules/npm/node_modules/cacache": {
       "version": "19.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4942,6 +4984,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/chownr": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4950,6 +4993,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/minizlib": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -4961,6 +5005,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/mkdirp": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -4975,6 +5020,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/tar": {
       "version": "7.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -4991,6 +5037,7 @@
     },
     "node_modules/npm/node_modules/cacache/node_modules/yallist": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -4999,6 +5046,7 @@
     },
     "node_modules/npm/node_modules/chalk": {
       "version": "5.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5010,6 +5058,7 @@
     },
     "node_modules/npm/node_modules/chownr": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5018,6 +5067,7 @@
     },
     "node_modules/npm/node_modules/ci-info": {
       "version": "4.3.0",
+      "dev": true,
       "funding": [
         {
           "type": "github",
@@ -5032,6 +5082,7 @@
     },
     "node_modules/npm/node_modules/cidr-regex": {
       "version": "4.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5043,6 +5094,7 @@
     },
     "node_modules/npm/node_modules/cli-columns": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5055,6 +5107,7 @@
     },
     "node_modules/npm/node_modules/cmd-shim": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5063,6 +5116,7 @@
     },
     "node_modules/npm/node_modules/color-convert": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5074,16 +5128,19 @@
     },
     "node_modules/npm/node_modules/color-name": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/common-ancestor-path": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/cross-spawn": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5097,6 +5154,7 @@
     },
     "node_modules/npm/node_modules/cross-spawn/node_modules/which": {
       "version": "2.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5111,6 +5169,7 @@
     },
     "node_modules/npm/node_modules/cssesc": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5122,6 +5181,7 @@
     },
     "node_modules/npm/node_modules/debug": {
       "version": "4.4.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5138,6 +5198,7 @@
     },
     "node_modules/npm/node_modules/diff": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause",
       "engines": {
@@ -5146,16 +5207,19 @@
     },
     "node_modules/npm/node_modules/eastasianwidth": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/emoji-regex": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/encoding": {
       "version": "0.1.13",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5165,6 +5229,7 @@
     },
     "node_modules/npm/node_modules/env-paths": {
       "version": "2.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5173,16 +5238,19 @@
     },
     "node_modules/npm/node_modules/err-code": {
       "version": "2.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/exponential-backoff": {
       "version": "3.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0"
     },
     "node_modules/npm/node_modules/fastest-levenshtein": {
       "version": "1.0.16",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5191,6 +5259,7 @@
     },
     "node_modules/npm/node_modules/foreground-child": {
       "version": "3.3.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5206,6 +5275,7 @@
     },
     "node_modules/npm/node_modules/fs-minipass": {
       "version": "3.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5217,6 +5287,7 @@
     },
     "node_modules/npm/node_modules/glob": {
       "version": "10.4.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5236,11 +5307,13 @@
     },
     "node_modules/npm/node_modules/graceful-fs": {
       "version": "4.2.11",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/hosted-git-info": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5252,11 +5325,13 @@
     },
     "node_modules/npm/node_modules/http-cache-semantics": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause"
     },
     "node_modules/npm/node_modules/http-proxy-agent": {
       "version": "7.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5269,6 +5344,7 @@
     },
     "node_modules/npm/node_modules/https-proxy-agent": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5281,6 +5357,7 @@
     },
     "node_modules/npm/node_modules/iconv-lite": {
       "version": "0.6.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true,
@@ -5293,6 +5370,7 @@
     },
     "node_modules/npm/node_modules/ignore-walk": {
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5304,6 +5382,7 @@
     },
     "node_modules/npm/node_modules/imurmurhash": {
       "version": "0.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5312,6 +5391,7 @@
     },
     "node_modules/npm/node_modules/ini": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5320,6 +5400,7 @@
     },
     "node_modules/npm/node_modules/init-package-json": {
       "version": "8.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5337,6 +5418,7 @@
     },
     "node_modules/npm/node_modules/ip-address": {
       "version": "9.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5349,6 +5431,7 @@
     },
     "node_modules/npm/node_modules/ip-regex": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5360,6 +5443,7 @@
     },
     "node_modules/npm/node_modules/is-cidr": {
       "version": "5.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5371,6 +5455,7 @@
     },
     "node_modules/npm/node_modules/is-fullwidth-code-point": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5379,11 +5464,13 @@
     },
     "node_modules/npm/node_modules/isexe": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/jackspeak": {
       "version": "3.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -5398,11 +5485,13 @@
     },
     "node_modules/npm/node_modules/jsbn": {
       "version": "1.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/json-parse-even-better-errors": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5411,6 +5500,7 @@
     },
     "node_modules/npm/node_modules/json-stringify-nice": {
       "version": "1.1.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -5419,6 +5509,7 @@
     },
     "node_modules/npm/node_modules/jsonparse": {
       "version": "1.3.1",
+      "dev": true,
       "engines": [
         "node >= 0.2.0"
       ],
@@ -5427,16 +5518,19 @@
     },
     "node_modules/npm/node_modules/just-diff": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/just-diff-apply": {
       "version": "5.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/libnpmaccess": {
       "version": "10.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5449,6 +5543,7 @@
     },
     "node_modules/npm/node_modules/libnpmdiff": {
       "version": "8.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5467,6 +5562,7 @@
     },
     "node_modules/npm/node_modules/libnpmexec": {
       "version": "10.1.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5488,6 +5584,7 @@
     },
     "node_modules/npm/node_modules/libnpmfund": {
       "version": "7.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5499,6 +5596,7 @@
     },
     "node_modules/npm/node_modules/libnpmorg": {
       "version": "8.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5511,6 +5609,7 @@
     },
     "node_modules/npm/node_modules/libnpmpack": {
       "version": "9.0.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5525,6 +5624,7 @@
     },
     "node_modules/npm/node_modules/libnpmpublish": {
       "version": "11.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5543,6 +5643,7 @@
     },
     "node_modules/npm/node_modules/libnpmsearch": {
       "version": "9.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5554,6 +5655,7 @@
     },
     "node_modules/npm/node_modules/libnpmteam": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5566,6 +5668,7 @@
     },
     "node_modules/npm/node_modules/libnpmversion": {
       "version": "8.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5581,11 +5684,13 @@
     },
     "node_modules/npm/node_modules/lru-cache": {
       "version": "10.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
     "node_modules/npm/node_modules/make-fetch-happen": {
       "version": "14.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5607,6 +5712,7 @@
     },
     "node_modules/npm/node_modules/make-fetch-happen/node_modules/negotiator": {
       "version": "1.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -5615,6 +5721,7 @@
     },
     "node_modules/npm/node_modules/minimatch": {
       "version": "9.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5629,6 +5736,7 @@
     },
     "node_modules/npm/node_modules/minipass": {
       "version": "7.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5637,6 +5745,7 @@
     },
     "node_modules/npm/node_modules/minipass-collect": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5648,6 +5757,7 @@
     },
     "node_modules/npm/node_modules/minipass-fetch": {
       "version": "4.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5664,6 +5774,7 @@
     },
     "node_modules/npm/node_modules/minipass-fetch/node_modules/minizlib": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5675,6 +5786,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush": {
       "version": "1.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5686,6 +5798,7 @@
     },
     "node_modules/npm/node_modules/minipass-flush/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5697,6 +5810,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline": {
       "version": "1.2.4",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5708,6 +5822,7 @@
     },
     "node_modules/npm/node_modules/minipass-pipeline/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5719,6 +5834,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized": {
       "version": "1.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5730,6 +5846,7 @@
     },
     "node_modules/npm/node_modules/minipass-sized/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5741,6 +5858,7 @@
     },
     "node_modules/npm/node_modules/minizlib": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5753,6 +5871,7 @@
     },
     "node_modules/npm/node_modules/minizlib/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5764,6 +5883,7 @@
     },
     "node_modules/npm/node_modules/mkdirp": {
       "version": "1.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5775,11 +5895,13 @@
     },
     "node_modules/npm/node_modules/ms": {
       "version": "2.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/mute-stream": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5788,6 +5910,7 @@
     },
     "node_modules/npm/node_modules/node-gyp": {
       "version": "11.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5811,6 +5934,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/chownr": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5819,6 +5943,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/minizlib": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -5830,6 +5955,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/mkdirp": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "bin": {
@@ -5844,6 +5970,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/tar": {
       "version": "7.4.3",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5860,6 +5987,7 @@
     },
     "node_modules/npm/node_modules/node-gyp/node_modules/yallist": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "engines": {
@@ -5868,6 +5996,7 @@
     },
     "node_modules/npm/node_modules/nopt": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5882,6 +6011,7 @@
     },
     "node_modules/npm/node_modules/normalize-package-data": {
       "version": "7.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5895,6 +6025,7 @@
     },
     "node_modules/npm/node_modules/npm-audit-report": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5903,6 +6034,7 @@
     },
     "node_modules/npm/node_modules/npm-bundled": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5914,6 +6046,7 @@
     },
     "node_modules/npm/node_modules/npm-install-checks": {
       "version": "7.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "dependencies": {
@@ -5925,6 +6058,7 @@
     },
     "node_modules/npm/node_modules/npm-normalize-package-bin": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -5933,6 +6067,7 @@
     },
     "node_modules/npm/node_modules/npm-package-arg": {
       "version": "12.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5947,6 +6082,7 @@
     },
     "node_modules/npm/node_modules/npm-packlist": {
       "version": "10.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5958,6 +6094,7 @@
     },
     "node_modules/npm/node_modules/npm-pick-manifest": {
       "version": "10.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5972,6 +6109,7 @@
     },
     "node_modules/npm/node_modules/npm-profile": {
       "version": "11.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -5984,6 +6122,7 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch": {
       "version": "18.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6002,6 +6141,7 @@
     },
     "node_modules/npm/node_modules/npm-registry-fetch/node_modules/minizlib": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6013,6 +6153,7 @@
     },
     "node_modules/npm/node_modules/npm-user-validate": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-2-Clause",
       "engines": {
@@ -6021,6 +6162,7 @@
     },
     "node_modules/npm/node_modules/p-map": {
       "version": "7.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6032,11 +6174,13 @@
     },
     "node_modules/npm/node_modules/package-json-from-dist": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0"
     },
     "node_modules/npm/node_modules/pacote": {
       "version": "21.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6067,6 +6211,7 @@
     },
     "node_modules/npm/node_modules/parse-conflict-json": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6080,6 +6225,7 @@
     },
     "node_modules/npm/node_modules/path-key": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6088,6 +6234,7 @@
     },
     "node_modules/npm/node_modules/path-scurry": {
       "version": "1.11.1",
+      "dev": true,
       "inBundle": true,
       "license": "BlueOak-1.0.0",
       "dependencies": {
@@ -6103,6 +6250,7 @@
     },
     "node_modules/npm/node_modules/postcss-selector-parser": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6115,6 +6263,7 @@
     },
     "node_modules/npm/node_modules/proc-log": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6123,6 +6272,7 @@
     },
     "node_modules/npm/node_modules/proggy": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6131,6 +6281,7 @@
     },
     "node_modules/npm/node_modules/promise-all-reject-late": {
       "version": "1.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6139,6 +6290,7 @@
     },
     "node_modules/npm/node_modules/promise-call-limit": {
       "version": "3.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "funding": {
@@ -6147,6 +6299,7 @@
     },
     "node_modules/npm/node_modules/promise-retry": {
       "version": "2.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6159,6 +6312,7 @@
     },
     "node_modules/npm/node_modules/promzard": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6170,6 +6324,7 @@
     },
     "node_modules/npm/node_modules/qrcode-terminal": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "bin": {
         "qrcode-terminal": "bin/qrcode-terminal.js"
@@ -6177,6 +6332,7 @@
     },
     "node_modules/npm/node_modules/read": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6188,6 +6344,7 @@
     },
     "node_modules/npm/node_modules/read-cmd-shim": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6196,6 +6353,7 @@
     },
     "node_modules/npm/node_modules/read-package-json-fast": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6208,6 +6366,7 @@
     },
     "node_modules/npm/node_modules/retry": {
       "version": "0.12.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6216,12 +6375,14 @@
     },
     "node_modules/npm/node_modules/safer-buffer": {
       "version": "2.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/npm/node_modules/semver": {
       "version": "7.7.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "bin": {
@@ -6233,6 +6394,7 @@
     },
     "node_modules/npm/node_modules/shebang-command": {
       "version": "2.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6244,6 +6406,7 @@
     },
     "node_modules/npm/node_modules/shebang-regex": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6252,6 +6415,7 @@
     },
     "node_modules/npm/node_modules/signal-exit": {
       "version": "4.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6263,6 +6427,7 @@
     },
     "node_modules/npm/node_modules/sigstore": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6279,6 +6444,7 @@
     },
     "node_modules/npm/node_modules/smart-buffer": {
       "version": "4.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6288,6 +6454,7 @@
     },
     "node_modules/npm/node_modules/socks": {
       "version": "2.8.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6301,6 +6468,7 @@
     },
     "node_modules/npm/node_modules/socks-proxy-agent": {
       "version": "8.0.5",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6314,6 +6482,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct": {
       "version": "3.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6323,6 +6492,7 @@
     },
     "node_modules/npm/node_modules/spdx-correct/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6332,11 +6502,13 @@
     },
     "node_modules/npm/node_modules/spdx-exceptions": {
       "version": "2.5.0",
+      "dev": true,
       "inBundle": true,
       "license": "CC-BY-3.0"
     },
     "node_modules/npm/node_modules/spdx-expression-parse": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6346,16 +6518,19 @@
     },
     "node_modules/npm/node_modules/spdx-license-ids": {
       "version": "3.0.21",
+      "dev": true,
       "inBundle": true,
       "license": "CC0-1.0"
     },
     "node_modules/npm/node_modules/sprintf-js": {
       "version": "1.1.3",
+      "dev": true,
       "inBundle": true,
       "license": "BSD-3-Clause"
     },
     "node_modules/npm/node_modules/ssri": {
       "version": "12.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6367,6 +6542,7 @@
     },
     "node_modules/npm/node_modules/string-width": {
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6381,6 +6557,7 @@
     "node_modules/npm/node_modules/string-width-cjs": {
       "name": "string-width",
       "version": "4.2.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6394,6 +6571,7 @@
     },
     "node_modules/npm/node_modules/strip-ansi": {
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6406,6 +6584,7 @@
     "node_modules/npm/node_modules/strip-ansi-cjs": {
       "name": "strip-ansi",
       "version": "6.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6417,6 +6596,7 @@
     },
     "node_modules/npm/node_modules/supports-color": {
       "version": "10.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6428,6 +6608,7 @@
     },
     "node_modules/npm/node_modules/tar": {
       "version": "6.2.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6444,6 +6625,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass": {
       "version": "2.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6455,6 +6637,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/fs-minipass/node_modules/minipass": {
       "version": "3.3.6",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6466,6 +6649,7 @@
     },
     "node_modules/npm/node_modules/tar/node_modules/minipass": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6474,16 +6658,19 @@
     },
     "node_modules/npm/node_modules/text-table": {
       "version": "0.2.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tiny-relative-date": {
       "version": "1.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/tinyglobby": {
       "version": "0.2.14",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6499,6 +6686,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/fdir": {
       "version": "6.4.6",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "peerDependencies": {
@@ -6512,6 +6700,7 @@
     },
     "node_modules/npm/node_modules/tinyglobby/node_modules/picomatch": {
       "version": "4.0.3",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6523,6 +6712,7 @@
     },
     "node_modules/npm/node_modules/treeverse": {
       "version": "3.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6531,6 +6721,7 @@
     },
     "node_modules/npm/node_modules/tuf-js": {
       "version": "3.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6544,6 +6735,7 @@
     },
     "node_modules/npm/node_modules/unique-filename": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6555,6 +6747,7 @@
     },
     "node_modules/npm/node_modules/unique-slug": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6566,11 +6759,13 @@
     },
     "node_modules/npm/node_modules/util-deprecate": {
       "version": "1.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/validate-npm-package-license": {
       "version": "3.0.4",
+      "dev": true,
       "inBundle": true,
       "license": "Apache-2.0",
       "dependencies": {
@@ -6580,6 +6775,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-license/node_modules/spdx-expression-parse": {
       "version": "3.0.1",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6589,6 +6785,7 @@
     },
     "node_modules/npm/node_modules/validate-npm-package-name": {
       "version": "6.0.2",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6597,6 +6794,7 @@
     },
     "node_modules/npm/node_modules/walk-up-path": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6605,6 +6803,7 @@
     },
     "node_modules/npm/node_modules/which": {
       "version": "5.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6619,6 +6818,7 @@
     },
     "node_modules/npm/node_modules/which/node_modules/isexe": {
       "version": "3.1.1",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "engines": {
@@ -6627,6 +6827,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi": {
       "version": "8.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6644,6 +6845,7 @@
     "node_modules/npm/node_modules/wrap-ansi-cjs": {
       "name": "wrap-ansi",
       "version": "7.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6660,6 +6862,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi-cjs/node_modules/ansi-styles": {
       "version": "4.3.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6674,6 +6877,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/ansi-regex": {
       "version": "6.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "engines": {
@@ -6685,11 +6889,13 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/emoji-regex": {
       "version": "9.2.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT"
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/string-width": {
       "version": "5.1.2",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6706,6 +6912,7 @@
     },
     "node_modules/npm/node_modules/wrap-ansi/node_modules/strip-ansi": {
       "version": "7.1.0",
+      "dev": true,
       "inBundle": true,
       "license": "MIT",
       "dependencies": {
@@ -6720,6 +6927,7 @@
     },
     "node_modules/npm/node_modules/write-file-atomic": {
       "version": "6.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC",
       "dependencies": {
@@ -6732,6 +6940,7 @@
     },
     "node_modules/npm/node_modules/yallist": {
       "version": "4.0.0",
+      "dev": true,
       "inBundle": true,
       "license": "ISC"
     },
@@ -7012,7 +7221,6 @@
       "resolved": "https://registry.npmjs.org/preact/-/preact-10.12.1.tgz",
       "integrity": "sha512-l8386ixSsBdbreOAkqtrwqHwdvR35ID8c3rKPa8lCWuO86dBi32QWHV4vfsZK1utLLFMvw+Z5Ad4XLkZzchscg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/preact"

--- a/package.json
+++ b/package.json
@@ -13,10 +13,11 @@
     "deploy": "gh-pages -d dist"
   },
   "dependencies": {
-    "@fullcalendar/daygrid": "^6.1.18",
-    "@fullcalendar/interaction": "^6.1.18",
-    "@fullcalendar/react": "^6.1.18",
-    "@fullcalendar/timegrid": "^6.1.18",
+    "@fullcalendar/core": "^6.1.19",
+    "@fullcalendar/daygrid": "^6.1.19",
+    "@fullcalendar/interaction": "^6.1.19",
+    "@fullcalendar/react": "^6.1.19",
+    "@fullcalendar/timegrid": "^6.1.19",
     "react": "^18.2.0",
     "react-dom": "^18.2.0"
   },

--- a/src/study/dashboard/StudyCalendar.jsx
+++ b/src/study/dashboard/StudyCalendar.jsx
@@ -1,8 +1,7 @@
 
 import React, { useState, useEffect, useMemo } from 'react';
-import { useParams } from "react-router-dom";
 import axios from 'axios';
-import './StudyCalendar.css';
+import { useParams } from "react-router-dom";
 
 import FullCalendar from '@fullcalendar/react';
 import dayGridPlugin from '@fullcalendar/daygrid';
@@ -11,6 +10,8 @@ import interactionPlugin from '@fullcalendar/interaction';
 
 import { useAuth } from '../../contexts/AuthContext';
 import { useStudy } from '../../contexts/StudyContext';
+
+import './StudyCalendar.css';
 
 export default function StudyCalendar() {
   const [events, setEvents] = useState([]);
@@ -76,8 +77,14 @@ export default function StudyCalendar() {
           'X-USER-ID': userId
         }
       });
-      const saved = res.data;
 
+      // 전체 응답 구조를 확인
+  console.log('전체 응답 객체:', res);
+  console.log('응답 status:', res.status);
+  console.log('응답 headers:', res.headers);
+  console.log('응답 data:', res.data);
+  console.log('res.data의 타입:', typeof res.data);
+      const saved = res.data;
       // 화면에 바로 반영
       setEvents((prev) => [
         ...prev,
@@ -92,12 +99,23 @@ export default function StudyCalendar() {
           extendedProps: { content: saved.content },
         },
       ]);
-
+      
+      console.log('백엔드 응답:', saved);
+      console.log('추가하려는 이벤트:', {
+        id: saved.id,
+        title: saved.title,
+        start: saved.startDate,
+        end: saved.endDate,
+        backgroundColor: saved.bgColor,
+        textColor: saved.textColor,
+        extendedProps: { content: saved.content },
+      });
       alert('등록 완료');
     } catch (err) {
       console.error("등록 실패:", err);
       alert('등록 실패');
     }
+    
   };
 
   // 일정 클릭(모달 열기)

--- a/src/study/dashboard/StudyMain.jsx
+++ b/src/study/dashboard/StudyMain.jsx
@@ -4,6 +4,7 @@ import axios from 'axios';
 import { useAuth } from '../../contexts/AuthContext';
 import { useStudy } from '../../contexts/StudyContext';
 import './StudyMain.css';
+import WeeklyCalendar from './WeeklyCalendar';
 
 export default function StudyMain() {
   const { groupId } = useParams(); // URL 파라미터로부터 studyId 추출
@@ -211,7 +212,7 @@ export default function StudyMain() {
       </div>
       {/* 주간 캘린더 자리 */}
       <div className='week-calendar'>
-        <h1>주간 캘린더 자리임</h1>
+        <WeeklyCalendar />
       </div>
 
       {/* 글 작성 영역 */}

--- a/src/study/dashboard/WeeklyCalendar.css
+++ b/src/study/dashboard/WeeklyCalendar.css
@@ -1,0 +1,165 @@
+/* WeeklyCalendar.css */
+
+.weekly-calendar-container {
+  background: white;
+  border-radius: 8px;
+  padding: 20px;
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+  margin: 20px 0;
+}
+
+.loading {
+  text-align: center;
+  padding: 40px;
+  color: #666;
+  font-size: 14px;
+}
+
+/* FullCalendar 커스텀 스타일 */
+.fc {
+  font-family: inherit;
+}
+
+/* 헤더 스타일 */
+.fc-header-toolbar {
+  margin-bottom: 15px !important;
+  padding: 0 10px;
+}
+
+.fc-toolbar-title {
+  font-size: 1.1em !important;
+  font-weight: 600 !important;
+  color: #333 !important;
+}
+
+.fc-button {
+  background: #f8f9fa !important;
+  border: 1px solid #dee2e6 !important;
+  color: #495057 !important;
+  font-size: 0.85em !important;
+  padding: 0.375rem 0.75rem !important;
+  border-radius: 4px !important;
+}
+
+.fc-button:hover {
+  background: #e9ecef !important;
+  border-color: #adb5bd !important;
+}
+
+.fc-button-active {
+  background: #007bff !important;
+  border-color: #007bff !important;
+  color: white !important;
+}
+
+/* 주간 달력 전용 스타일 */
+.fc-timegrid {
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+}
+
+.fc-timegrid-slot {
+  height: 35px !important; /* 시간 슬롯 높이 조절 */
+}
+
+.fc-timegrid-slot-label {
+  font-size: 0.8em;
+  color: #666;
+}
+
+/* 요일 헤더 */
+.fc-col-header-cell {
+  background: #f8f9fa;
+  border-bottom: 2px solid #dee2e6;
+  font-weight: 600;
+  color: #495057;
+  padding: 8px 4px;
+}
+
+/* 오늘 날짜 강조 */
+.fc-day-today {
+  background: rgba(0, 123, 255, 0.1) !important;
+}
+
+.fc-day-today .fc-col-header-cell-cushion {
+  color: #007bff;
+  font-weight: bold;
+}
+
+/* 이벤트 스타일 */
+.fc-event {
+  border-radius: 4px;
+  border: none !important;
+  padding: 2px 4px;
+  font-size: 0.8em;
+  cursor: pointer;
+  transition: opacity 0.2s;
+}
+
+.fc-event:hover {
+  opacity: 0.8;
+}
+
+.fc-event-title {
+  font-weight: 500;
+}
+
+/* 현재 시간 표시선 */
+.fc-timegrid-now-indicator-line {
+  border-color: #dc3545;
+  border-width: 2px;
+}
+
+.fc-timegrid-now-indicator-arrow {
+  border-color: #dc3545;
+}
+
+/* 종일 이벤트 영역 */
+.fc-timegrid-divider {
+  background: #f8f9fa;
+  border-color: #dee2e6;
+}
+
+.fc-timegrid-allday-slot {
+  background: #f8f9fa;
+}
+
+/* 스크롤바 스타일링 (선택사항) */
+.fc-timegrid-body::-webkit-scrollbar {
+  width: 8px;
+}
+
+.fc-timegrid-body::-webkit-scrollbar-track {
+  background: #f1f1f1;
+  border-radius: 4px;
+}
+
+.fc-timegrid-body::-webkit-scrollbar-thumb {
+  background: #c1c1c1;
+  border-radius: 4px;
+}
+
+.fc-timegrid-body::-webkit-scrollbar-thumb:hover {
+  background: #a8a8a8;
+}
+
+/* 반응형 - 작은 화면에서 */
+@media (max-width: 768px) {
+  .weekly-calendar-container {
+    padding: 15px;
+    margin: 15px 0;
+  }
+  
+  .fc-toolbar-title {
+    font-size: 1em !important;
+  }
+  
+  .fc-button {
+    font-size: 0.75em !important;
+    padding: 0.25rem 0.5rem !important;
+  }
+  
+  .fc-timegrid-slot {
+    height: 30px !important;
+  }
+}

--- a/src/study/dashboard/WeeklyCalendar.jsx
+++ b/src/study/dashboard/WeeklyCalendar.jsx
@@ -1,0 +1,295 @@
+import React, { useState, useEffect, useMemo } from 'react';
+import axios from 'axios';
+import { useParams } from 'react-router-dom';
+
+import FullCalendar from '@fullcalendar/react';
+import dayGridPlugin from '@fullcalendar/daygrid';
+import interactionPlugin from '@fullcalendar/interaction';
+
+import { useAuth } from '../../contexts/AuthContext';
+import { useStudy } from '../../contexts/StudyContext';
+
+import './WeeklyCalendar.css';
+
+export default function WeeklyCalendar() {
+  // URL 파라미터 및 기본 설정
+  const { groupId: groupIdParam } = useParams();
+  const groupId = Number(groupIdParam);
+
+  // 상태 관리
+  const [events, setEvents] = useState([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [selectedEvent, setSelectedEvent] = useState(null); // 클릭한 일정 정보
+  const [showModal, setShowModal] = useState(false);
+  const [newTitle, setNewTitle] = useState('');
+  const [newContent, setNewContent] = useState('');
+
+  // Context 및 권환 관리 (월간 캘린더와 동일)
+  const { user } = useAuth(); // 현재 로그인한 사용자 정보
+  const userId = user?.id; // 사용자 ID (api 호출 시 사용)
+  const { studyInfo } = useStudy(); // 스터디 정보(studyContext에서 가져옴)
+  const [host, setHost] = useState(import.meta.env.VITE_AWS_API_HOST); // API 서버 주소
+
+  /* 스터디장 여부 확인
+    현재 로그인한 사용자가 스터디 그룹의 소뉴자인지 판단
+    스터디장만 일정 등록 수정 삭제 가눙 
+   */
+  const isHost = useMemo(() => {
+    return !!(user?.id && studyInfo?.groupOwnerId && user.id === studyInfo.groupOwnerId);
+  }, [user?.id, studyInfo?.groupOwnerId]);
+
+  // 데이터 조회(월간 캘린더와 동일한 API 사용)
+
+  // 캘린더 이벤트 데이터 가져오기
+  const fetchCalendarEvents = async () => {
+    try {
+      setIsLoading(true);
+      // 월간 캘린더와 동일한 API 엔드포인트 사용
+      const response = await axios.get(`${host}/api/study/calendar/study/${groupId}`);
+
+      // 백엔드 데이터를 FullCalendar 형식으로 변환
+      const formattedEvents = response.data.map(event => ({
+        id: event.id,
+        title: event.title,                              // 일정 제목
+        start: event.startDate,
+        end: event.endDate,
+        allDay: true, // 종일 일정으로 설정
+        backgroundColor: event.bgColor || '#FDB515',
+        textColor: event.textColor || '#666666',
+        extendedProps: { // 추가 데이터 (모달에서 사용)
+          content: event.content
+        }
+      }));
+      setEvents(formattedEvents);
+    } catch (error) {
+      console.error('캘린더 데이터 로딩 실패:', error);
+      setEvents([]); // 실패 시 빈 배열로 초기화
+    } finally {
+      setIsLoading(false);
+    }
+  };
+
+  // 컴포넌트 마운트 시 일정 데이터 로드
+  useEffect(() => {
+    if (groupId) {
+      fetchCalendarEvents();
+    }
+  }, [groupId]);
+
+  // 일정 등록 (스터디장만 가능)
+  const handleSelect = async (info) => {
+    // 권한 체크: 스터디장이 아니면 함수 종료
+    if (!isHost) return;
+
+    // 사용자 입력받기 (간단한 prompt 사용)
+    let title = prompt("제목을 입력하세요 (필수):");
+    if (!title) return;  // 제목이 없으면 취소
+    const content = prompt("내용을 입력하세요 (선택):");
+
+    // 백엔드로 전송할 데이터 구성 (월간 캘린더와 동일한 형식)
+    const newEvent = {
+      groupId,                    // 스터디 그룹 ID
+      title,                      // 일정 제목
+      content,                    // 일정 내용 (선택사항)
+      startDate: info.startStr,   // 시작 날짜
+      endDate: info.endStr,       // 종료 날짜
+      bgColor: "#FDB515",         // 월간 캘린더와 동일한 기본 배경색
+      textColor: "#666666",       // 월간 캘린더와 동일한 기본 텍스트 색상
+    };
+
+    try {
+      // API 호출: 일정 등록
+      const res = await axios.post(`${host}/api/study/calendar`, newEvent, {
+        headers: {
+          'X-USER-ID': userId  // 백엔드에서 작성자 확인용
+        }
+      });
+      const saved = res.data;  // 백엔드에서 저장된 일정 정보 반환
+
+      // 화면에 바로 반영 (페이지 새로고침 없이 즉시 표시)
+      setEvents((prev) => [
+        ...prev,
+        {
+          id: saved.id,
+          title: saved.title,
+          start: saved.startDate,
+          end: saved.endDate,
+          allDay: true,
+          backgroundColor: saved.bgColor,
+          textColor: saved.textColor,
+          extendedProps: { content: saved.content },
+        },
+      ]);
+
+      alert('등록 완료');
+    } catch (err) {
+      console.error("등록 실패:", err);
+      alert('등록 실패');
+    }
+  };
+
+  // 일정 상세보기
+  const handleEventClick = (clickInfo) => {
+    setSelectedEvent(clickInfo.event);
+    setNewTitle(clickInfo.event.title);
+    setNewContent(clickInfo.event.extendedProps.content || '');
+    setShowModal(true);
+  };
+
+  // 일정 수정
+  const handleUpdate = async () => {
+    try {
+      // API 호출: 일정 수정
+      await axios.put(`${host}/api/study/calendar`, {
+        id: selectedEvent.id,
+        title: newTitle,
+        content: newContent,
+        groupId: groupId,
+      }, {
+        headers: {
+          'X-USER-ID': userId
+        }
+      });
+
+      // 화면에서 즉시 업데이트 (FullCalendar 객체 직접 수정)
+      selectedEvent.setProp('title', newTitle);
+      selectedEvent.setExtendedProp('content', newContent);
+
+      alert('수정 완료');
+      setShowModal(false);  // 모달 닫기
+    } catch (err) {
+      console.error(err);
+      alert('수정 실패');
+    }
+  };
+
+  // 일정 삭제(스터디 장만)
+  const handleDelete = async () => {
+    // 삭제 확인
+    if (!window.confirm('삭제하시겠습니까?')) return;
+
+    try {
+      // API 호출: 일정 삭제
+      await axios.delete(`${host}/api/study/calendar/${selectedEvent.id}`, {
+        headers: {
+          'X-USER-ID': userId  // 권한 확인용
+        }
+      });
+
+      // 화면에서 즉시 제거
+      selectedEvent.remove();
+
+      alert('삭제 완료');
+      setShowModal(false);  // 모달 닫기
+    } catch {
+      alert('삭제 실패');
+    }
+  };
+
+  // 로딩 상태 UI
+  if (isLoading) {
+    return (
+      <div className="weekly-calendar-container">
+        <div className="loading">캘린더 로딩 중...</div>
+      </div>
+    );
+  }
+  return (
+    <div className="weekly-calendar-container">
+      {/* 캘린더 헤더 */}
+      <div className="calendar-header">
+        <h3>이번 주 일정</h3>
+      </div>
+
+      {/* FullCalendar 컴포넌트 */}
+      <FullCalendar
+        // 필수 플러그인
+        plugins={[dayGridPlugin, interactionPlugin]}
+
+        // 주간 보기로 설정 (월간 캘린더와의 차이점)
+        initialView="dayGridWeek"
+
+        // 헤더 설정 (간단하게 구성)
+        headerToolbar={{
+          left: 'prev,next',     // 이전/다음 버튼
+          center: 'title',       // 현재 주 표시
+          right: ''              // 보기 변경 버튼 없음 (주간 고정)
+        }}
+
+        // 한국어 설정
+        locale="ko"
+
+        // 높이 설정 (StudyMain에 적합한 컴팩트 사이즈)
+        height="200px"
+
+        // 권한별 설정
+        selectable={isHost}        // 스터디장만 날짜 선택 가능
+        select={handleSelect}      // 날짜 선택시 일정 등록 함수 실행
+
+        // 일정 데이터
+        events={events}
+
+        // 일정 클릭 처리 (모든 사용자 가능)
+        eventClick={handleEventClick}
+
+        // 기타 설정
+        weekends={true}            // 주말 표시
+        dayMaxEvents={3}           // 하루 최대 3개 일정 표시 (초과시 +more)
+        moreLinkClick="popover"    // +more 클릭시 팝오버로 표시
+
+        // 요일 헤더 형식 (예: 월 8/13)
+        dayHeaderFormat={{ weekday: 'short', month: 'numeric', day: 'numeric' }}
+      />
+
+      {/* ================================================================ */}
+      {/* 11. 일정 상세보기/수정 모달 (월간 캘린더와 동일한 구조)           */}
+      {/* ================================================================ */}
+
+      {showModal && (
+        <div className="modal-overlay">
+          <div className="modal-content">
+
+            {/* 제목 입력 섹션 */}
+            <div className="modal-section">
+              <div className="modal-label">제목</div>
+              <input
+                type='text'
+                value={newTitle}
+                onChange={(e) => setNewTitle(e.target.value)}
+                placeholder='제목을 입력하세요'
+                className="modal-input"
+                readOnly={!isHost}  // 스터디장만 수정 가능
+              />
+            </div>
+
+            {/* 내용 입력 섹션 */}
+            <div className="modal-section">
+              <div className="modal-label">내용</div>
+              <textarea
+                value={newContent}
+                onChange={(e) => setNewContent(e.target.value)}
+                placeholder='내용을 입력하세요'
+                rows="3"
+                className="modal-textarea"
+                readOnly={!isHost}  // 스터디장만 수정 가능
+              />
+            </div>
+
+            {/* 버튼 섹션 */}
+            <div className="modal-buttons">
+              {/* 스터디장만 수정/삭제 버튼 표시 */}
+              {isHost && (
+                <div className="action-buttons">
+                  <button onClick={handleUpdate} className="update-button">수정</button>
+                  <button onClick={handleDelete} className="delete-button">삭제</button>
+                </div>
+              )}
+              {/* 모든 사용자에게 닫기 버튼 표시 */}
+              <button onClick={() => setShowModal(false)} className="close-button">닫기</button>
+            </div>
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## 대시보드 주간 캘린더 기능 추가

### 기존 월간 캘린더와 연동
- **데이터 동기화**
  - 기존 월간 캘린더의 일정 데이터와 실시간 연동
  - 동일한 Calendar API 활용으로 일관성 유지
  - 월간에서 등록한 일정이 주간 뷰에 즉시 반영
  - FullCalendar timeGridWeek 플러그인 적용

### 주요 변경 파일
- 대시보드 컴포넌트에 주간 캘린더 위젯 추가
- 기존 Calendar API와 연동 로직 구현
